### PR TITLE
Fix PDOOci tests

### DIFF
--- a/ext/pdo_oci/tests/subclassing/pdooci_001.phpt
+++ b/ext/pdo_oci/tests/subclassing/pdooci_001.phpt
@@ -15,17 +15,12 @@ echo "PdoOci class exists.\n";
 
 [$dsn, $user, $pass] = getDsnUserAndPassword();
 
-var_dump([$dsn, $user, $pass]);
-exit(0);
-
-
-
 $db = new PdoOci($dsn, $user, $pass);
 
-$db->query('CREATE TABLE IF NOT EXISTS foobar (id INT, name TEXT)');
+$db->query('CREATE TABLE IF NOT EXISTS foobar(id NUMBER, name VARCHAR2(6))');
 
-$db->query('INSERT INTO foobar VALUES (NULL, "PHP")');
-$db->query('INSERT INTO foobar VALUES (NULL, "PHP6")');
+$db->query("INSERT INTO foobar VALUES (NULL, 'PHP')");
+$db->query("INSERT INTO foobar VALUES (NULL, 'PHP6')");
 
 foreach ($db->query('SELECT name FROM foobar') as $row) {
     var_dump($row);
@@ -36,15 +31,15 @@ $db->query('DROP TABLE foobar');
 echo "Fin.";
 ?>
 --EXPECT--
-PdoMySql class exists.
+PdoOci class exists.
 array(2) {
-  ["name"]=>
+  ["NAME"]=>
   string(3) "PHP"
   [0]=>
   string(3) "PHP"
 }
 array(2) {
-  ["name"]=>
+  ["NAME"]=>
   string(4) "PHP6"
   [0]=>
   string(4) "PHP6"

--- a/ext/pdo_oci/tests/subclassing/pdooci_002.phpt
+++ b/ext/pdo_oci/tests/subclassing/pdooci_002.phpt
@@ -23,7 +23,7 @@ if (!$db instanceof PdoOci) {
 }
 
 $db->query('DROP TABLE IF EXISTS test');
-$db->exec('CREATE TABLE IF NOT EXISTS test(id int NOT NULL PRIMARY KEY, name VARCHAR(10))');
+$db->exec('CREATE TABLE IF NOT EXISTS test(id NUMBER NOT NULL PRIMARY KEY, name VARCHAR2(10))');
 $db->exec("INSERT INTO test VALUES(1, 'A')");
 $db->exec("INSERT INTO test VALUES(2, 'B')");
 $db->exec("INSERT INTO test VALUES(3, 'C')");
@@ -37,21 +37,21 @@ $db->query('DROP TABLE test');
 echo "Fin.";
 ?>
 --EXPECT--
-PdoMysql class exists.
+PdoOci class exists.
 array(2) {
-  ["name"]=>
+  ["NAME"]=>
   string(1) "A"
   [0]=>
   string(1) "A"
 }
 array(2) {
-  ["name"]=>
+  ["NAME"]=>
   string(1) "B"
   [0]=>
   string(1) "B"
 }
 array(2) {
-  ["name"]=>
+  ["NAME"]=>
   string(1) "C"
   [0]=>
   string(1) "C"


### PR DESCRIPTION
I had to uppercase some expectation keys, but otherwise the behaviour seems reasonable.

Note that these are only expected to work on version 23c of Oracle because of the EXISTS feature in CREATEs and DROPs. Oracle 23c is available in [this image](https://hub.docker.com/r/gvenzl/oracle-free).